### PR TITLE
ensure to capture caught error inside catch

### DIFF
--- a/_includes/components/add-techcat.njk
+++ b/_includes/components/add-techcat.njk
@@ -323,11 +323,11 @@
         }
 
         showSuccessPopover(responseData);
-
-        console.log(responseData);
       }
     } catch (error) {
-      throw new Error(`Error: ${error.message}`);
+      if (Sentry) {
+        Sentry.captureException(error);
+      }
     }
 
   });


### PR DESCRIPTION
Right now, caught errors are most likely not making it to Sentry. This will ensure it does.